### PR TITLE
fix: add solana address flag exception for repeating characters

### DIFF
--- a/src/pages/content/components/twitter/tweetHandlers.tsx
+++ b/src/pages/content/components/twitter/tweetHandlers.tsx
@@ -92,10 +92,30 @@ export function handleTweetWithAddress(tweet: HTMLElement, tweetText: string, is
   const evmAddressRegex = /(0x[a-fA-F0-9]{40})/g;
   const solanaAddressRegex = /([1-9A-HJ-NP-Za-km-z]{32,44})/g;
 
-  // Check if the tweet text contains an EVM address
+  // Check if the tweet text contains an EVM or Solana address
   const hasEvmAddress = tweetText.match(evmAddressRegex);
   const hasSolAddress = tweetText.match(solanaAddressRegex);
   if (!hasEvmAddress && !hasSolAddress) return;
+
+  // excption for strings of lowercase letters that are identified as solana addresses
+  // only applies if there are no evm addresses
+  if (hasSolAddress && !hasEvmAddress) {
+    var numberOfFalsePositiveSolanaAddresses = 0;
+    // count number of unique lowercase letters in each solana address
+    for (const solanaAddress of hasSolAddress) {
+      const characters = solanaAddress.match(/[1-9A-HJ-NP-Za-km-z]/g);
+      // remove duplicates from array
+      const uniqueCharacters = [...new Set(characters)];
+      // if there are less than 6 unique characters, then it's almost certainly not a solana address
+      if (uniqueCharacters.length < 6) {
+        numberOfFalsePositiveSolanaAddresses++;
+      }
+    }
+    // if all solana addresses were identified as false positives, then don't display warning message
+    if (hasSolAddress.length == numberOfFalsePositiveSolanaAddresses) {
+      return;
+    }
+  }
 
   // display warning message on tweet
   const dynamicWarningChainString = hasEvmAddress ? "An Ethereum/EVM" : "A Solana";


### PR DESCRIPTION
Fixes #40 

Added a check to the tweethander that uses a heuristic to identify strings of characters that look like solana addresses but aren't.