### PR TITLE
Fix debounce util

### DIFF
--- a/src/pages/libs/helpers.ts
+++ b/src/pages/libs/helpers.ts
@@ -124,12 +124,10 @@ export const setStorage = async <T>(area: "local" | "sync", key: string, value: 
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-export const debounceTimers = {} as Record<number, NodeJS.Timeout>;
-export function debounce(func: Function, delay: number) {
-  return function () {
-    const context = this;
-    const args = arguments;
-    clearTimeout(debounceTimers[delay]);
-    debounceTimers[delay] = setTimeout(() => func.apply(context, args), delay);
+export function debounce<T extends (...args: any[]) => any>(fn: T, delay: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return function (this: ThisParameterType<T>, ...args: Parameters<T>) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(this, args), delay);
   };
 }


### PR DESCRIPTION
current implementation store timers in a global `Record<number, NodeJS.Timeout>` keyed by delay, which caused collisions between unrelated functions sharing the same `delay` + it also relied on a Node-specific timeout type in a extension context.

replaced to closure-based one that each `debounce(fn, delay)` returns a wrapper that manages its own timer + uses `ReturnType<typeof setTimeout>`.