### PR TITLE
fix: prevent destructuring error when fetchData returns undefined

### DIFF
--- a/src/pages/libs/db.ts
+++ b/src/pages/libs/db.ts
@@ -135,7 +135,7 @@ export async function updateDb() {
     updateFrequency: 60 * 60, // update every 60 minutes
     getData,
   })
-  const { allowedDomains = [], blockedDomains = [], fuzzyDomains = [], protocols = [] } = res;
+  const { allowedDomains = [], blockedDomains = [], fuzzyDomains = [], protocols = [] } = res || {};
   allowedDomainsDb.data = new Set([...allowedDomains, ...LOCAL_ALLOWED_DOMAINS]);
   blockedDomainsDb.data = new Set([...blockedDomains, ...LOCAL_BLOCKED_DOMAINS]);
   fuzzyDomainsDb.data = fuzzyDomains;


### PR DESCRIPTION
## Summary

This ensures that even if `res` is `undefined`, the destructuring will work against an empty object `{}`, and all variables will get their default empty array values, preventing the "Cannot read properties of undefined" error.

- Closes: https://github.com/DefiLlama/defillama-extension/issues/61