### PR TITLE
fix: twitter address detection

### DIFF
--- a/src/pages/content/components/twitter/init.tsx
+++ b/src/pages/content/components/twitter/init.tsx
@@ -23,7 +23,8 @@ export default async function initPhishingDetector() {
   const twitterHashTags = await getStorage("local", "settings:twitterHashTags", false);
   const twitterQT = await getStorage("local", "settings:twitterQT", false);
   const twitterBotReplies = await getStorage("local", "settings:twitterBotReplies", false);
-  const twitterConfig = { twitterCashTags, twitterHashTags, twitterQT,  twitterBotReplies, };
+  const twitterAddresses = await getStorage("local", "settings:twitterAddresses", false);
+  const twitterConfig = { twitterCashTags, twitterHashTags, twitterQT, twitterBotReplies, twitterAddresses, };
   if (!phishingHandleDetector) return;
 
   let handlePage = getHandlerForTwitterPageVariant();

--- a/src/pages/content/components/twitter/pageHandlers.tsx
+++ b/src/pages/content/components/twitter/pageHandlers.tsx
@@ -31,12 +31,13 @@ type TwitterConfig = {
   twitterHashTags: boolean;
   twitterQT: boolean;
   twitterBotReplies: boolean;
+  twitterAddresses: boolean;
 };
 
 /**
  * Analyze tweets (op and replies) on the linked status page
  */
-export async function handleTweetStatusPage({ twitterCashTags, twitterHashTags, twitterQT, twitterBotReplies, }: TwitterConfig) {
+export async function handleTweetStatusPage({ twitterCashTags, twitterHashTags, twitterQT, twitterBotReplies, twitterAddresses, }: TwitterConfig) {
   const pathname = window.location.pathname;
 
   // check that the current page is a tweet page (not home/timeline page). Check done here in addition to in init page handler router to catch any edge cases
@@ -135,8 +136,8 @@ export async function handleTweetStatusPage({ twitterCashTags, twitterHashTags, 
         return;
       }
  */
-      // only hide addresses if not from the op
-      // if (!!tweetText) handleTweetWithAddress(tweet, tweetText, isLinkedTweet);  // disabled for now, since it is not working properly
+      // only hide addresses if not from the op (OP tweets return early above, so this is safe)
+      if (twitterAddresses && tweetText) handleTweetWithAddress(tweet, tweetText, isLinkedTweet);
       if (twitterCashTags && tweetText) handleCashTag(tweet, tweetText, isLinkedTweet);
       if (twitterHashTags && tweetText) handleHashTag(tweet, tweetText, isLinkedTweet);
       if (twitterQT && tweetText) handleQT(tweet, tweetText, isLinkedTweet);

--- a/src/pages/content/components/twitter/tweetHandlers.tsx
+++ b/src/pages/content/components/twitter/tweetHandlers.tsx
@@ -85,18 +85,76 @@ export function handleOpTweet(tweet: HTMLElement) {
 }
 
 /**
+ * Extracts the main tweet text, excluding quoted tweet text.
+ * When there are multiple tweetText elements, returns the first one (main tweet).
+ */
+function getMainTweetText(tweet: HTMLElement): string {
+  const allTweetTexts = tweet.querySelectorAll<HTMLElement>('[data-testid="tweetText"]');
+  if (allTweetTexts.length === 0) return '';
+  
+  // Get the first tweetText element (main tweet, not quoted tweet)
+  const mainTweetText = allTweetTexts[0]?.innerText.trim() || '';
+  return mainTweetText;
+}
+
+/**
+ * Checks if an address exists in link hrefs within the tweet.
+ * Returns the address if found, null otherwise.
+ */
+function findAddressInLinks(tweet: HTMLElement): string | null {
+  const links = tweet.querySelectorAll<HTMLAnchorElement>('a[href]');
+  for (const link of links) {
+    const href = link.href || '';
+    // Check for EVM addresses in href
+    const evmMatch = href.match(/0x[a-fA-F0-9]{40}/);
+    if (evmMatch) return evmMatch[0];
+    // Check for Solana addresses in href (base58, 32-44 chars, typically in solana explorer URLs)
+    // Solana addresses are base58 encoded, exclude 0, O, I, l to avoid confusion
+    const solanaMatch = href.match(/[1-9A-HJ-NP-Za-km-z]{32,44}/);
+    if (solanaMatch) {
+      const match = solanaMatch[0];
+      // Solana addresses are typically 32-44 characters, and often appear in explorer URLs
+      if (match.length >= 32 && match.length <= 44) {
+        return match;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Adds a warning message to the tweet if it contains an ethereum/evm or solana address.
+ * Only checks the main tweet text (not quoted tweets) and link hrefs.
  */
 export function handleTweetWithAddress(tweet: HTMLElement, tweetText: string, isLinkedTweet: boolean) {
-  // Regex for EVM and Solana addresses, respectively
-  const evmAddressRegex = /(0x[a-fA-F0-9]{40})/g;
-
-  // Check if the tweet text contains an EVM address
-  const hasEvmAddress = tweetText.match(evmAddressRegex);
-  if (!hasEvmAddress) return;
-
-  // display warning message on tweet
-  const warningTextContent = `An Ethereum/EVM address was detected in this reply. Proceed with caution.`;
+  // Get the main tweet text (first tweetText element, excluding quoted tweets)
+  const mainText = getMainTweetText(tweet);
+  
+  // Regex for EVM and Solana addresses
+  const evmAddressRegex = /\b0x[a-fA-F0-9]{40}\b/g; // Word boundaries to avoid partial matches
+  // Solana addresses are base58 encoded (32-44 chars), use word boundaries to avoid false positives
+  const solanaAddressRegex = /\b[1-9A-HJ-NP-Za-km-z]{32,44}\b/g;
+  
+  // Check if the main tweet text contains an address
+  const hasEvmAddress = mainText.match(evmAddressRegex);
+  const hasSolanaAddress = mainText.match(solanaAddressRegex);
+  
+  // Also check link hrefs for addresses
+  const addressInLink = findAddressInLinks(tweet);
+  
+  // If no address found in text or links, return early
+  if (!hasEvmAddress && !hasSolanaAddress && !addressInLink) return;
+  
+  // Determine which type of address was found for the warning message
+  let addressType = 'blockchain';
+  if (hasEvmAddress || (addressInLink && addressInLink.startsWith('0x'))) {
+    addressType = 'Ethereum/EVM';
+  } else if (hasSolanaAddress || addressInLink) {
+    addressType = 'Solana';
+  }
+  
+  // Display warning message on tweet
+  const warningTextContent = `${addressType} address detected in this reply. Proceed with caution.`;
   insertTweetWarningMessage(tweet, isLinkedTweet, warningTextContent);
 }
 

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -65,6 +65,7 @@ const Popup = () => {
   const [twitterHashTags, setTwitterHashTags] = useBrowserStorage("local", "settings:twitterHashTags", false,);
   const [twitterQT, setTwitterQT] = useBrowserStorage("local", "settings:twitterQT", false,);
   const [twitterBotReplies, setTwitterBotReplies] = useBrowserStorage("local", "settings:twitterBotReplies", false,);
+  const [twitterAddresses, setTwitterAddresses] = useBrowserStorage("local", "settings:twitterAddresses", false,);
 
   return (
     <Box w="xs" py="4" px="4" userSelect="none">
@@ -236,6 +237,19 @@ const Popup = () => {
             isChecked={twitterHashTags}
             onChange={(e) => {
               setTwitterHashTags(e.target.checked);
+              if (!e.target.checked) {
+                Browser.action.setIcon({ path: cuteStatic });
+              }
+            }}
+          />
+        </HStack>
+        <HStack justify="space-between" w="full" pl={7}>
+          <Text fontSize="sm">Hide addresses</Text>
+          <Switch
+            size="sm"
+            isChecked={twitterAddresses}
+            onChange={(e) => {
+              setTwitterAddresses(e.target.checked);
               if (!e.target.checked) {
                 Browser.action.setIcon({ path: cuteStatic });
               }


### PR DESCRIPTION
### What
- Fixed the detection for EVM addresses in tweet replies, and re-added Solana address detection as it's so common these days.
- Added an option to toggle it on/off.

### Screenshots
**Option:**
<img width="314" height="598" alt="Screenshot 2026-01-26 at 21 31 25" src="https://github.com/user-attachments/assets/f1ef8248-e3b6-409d-b0db-278687767b38" /><br />

**Example:**
<img width="586" height="130" alt="Screenshot 2026-01-26 at 21 29 32" src="https://github.com/user-attachments/assets/3e67cedb-fc39-4689-b651-079d9f22dbbf" />
